### PR TITLE
temp fix for webpack build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,12 @@
     "start": "start-storybook -p 6006",
     "pub": "npm run build && npm publish pkg",
     "build": "pack build",
+    "postbuild": "ln -s dist-src pkg/es && ln -s dist-src pkg/lib",
     "deploy": "storybook-to-ghpages",
     "lint-staged": "lint-staged"
   },
   "devDependencies": {
+    "@pika/pack": "^0.4.0",
     "@pika/plugin-build-types": "^0.5.1",
     "@pika/plugin-build-web": "^0.5.1",
     "@pika/plugin-standard-pkg": "^0.5.1",


### PR DESCRIPTION
temp fix for https://github.com/yiminghe/css-animation/issues/20 and similarly https://github.com/ant-design/ant-design/issues/17928

some libraries like antd rely on generated package files and it [hardcoded the path there](https://github.com/ant-design/ant-design/blob/master/components/_util/wave.tsx#L3), and giving that the pack builder used in the problematic PR also [hardcoding the destination path](https://github.com/pikapkg/builders/blob/master/packages/plugin-standard-pkg/src/index.ts#L38), I thought this PR could temporarily help.